### PR TITLE
Fixes error where array_shift requires a reference

### DIFF
--- a/Highrise.php
+++ b/Highrise.php
@@ -32,7 +32,8 @@ class Highrise {
 	function __construct($subdomain, $token){
 	
 		// subdomain
-		$subdomain = array_shift(explode('.', $subdomain));
+		$exploded = explode('.', $subdomain);
+		$subdomain = array_shift($exploded);
 		$this->apiUrl = str_replace('{sub}', $subdomain, $this->apiUrl);
 		
 		// token


### PR DESCRIPTION
The issue is that array_shift requires a reference, but the returned array value from explode does not give a reference.